### PR TITLE
Add basic testing scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /public
 /ssl
 /app/Console
-/tests
 /vendor
 /storage
 /geth-linux-amd64-1.9.15-0f77f34b

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# BitsArcade
+
+This repository contains a Laravel-based project. The original codebase did not include any automated test scaffolding, which made it difficult to verify changes.
+
+## Running tests
+
+1. Install PHP dependencies (including development packages):
+   ```bash
+   composer install --ignore-platform-reqs
+   ```
+2. Run the test suite:
+   ```bash
+   composer test
+   ```
+
+Currently only a placeholder test exists. Front-end tests have not been set up yet.
+
+For additional details about the project, see [DOCUMENTATION.md](DOCUMENTATION.md).

--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,7 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
-        ]
+        ],
+        "test": "phpunit"
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "watch-poll": "npm run watch -- --watch-poll",
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "test": "echo \"No front-end tests configured\""
     },
     "devDependencies": {
         "axios": "^0.19",

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+    public function testTruth(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- Add project README with testing instructions
- Expose simple `composer test` and `npm test` scripts
- Include placeholder PHPUnit test

## Testing
- `composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs` *(fails: could not clone private dependency)*
- `composer test` *(fails: phpunit not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f2aa50c0c83299cb52e54fb7c9561