### PR TITLE
Add test coverage for Promocode::generate

### DIFF
--- a/tests/PromocodeTest.php
+++ b/tests/PromocodeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+// Attempt to load Composer's autoloader; fall back to requiring the class directly
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require __DIR__ . '/../vendor/autoload.php';
+}
+
+if (!class_exists('App\\Promocode')) {
+    require __DIR__ . '/../app/Promocode.php';
+}
+
+use App\Promocode;
+use PHPUnit\Framework\TestCase;
+
+class PromocodeTest extends TestCase
+{
+    public function testGenerateReturnsEightUppercaseCharacters(): void
+    {
+        $code = Promocode::generate();
+        $this->assertSame(8, strlen($code));
+        $this->assertSame(strtoupper($code), $code);
+    }
+
+    public function testGenerateProducesUniqueCodes(): void
+    {
+        $codes = [];
+        for ($i = 0; $i < 5; $i++) {
+            $codes[] = Promocode::generate();
+        }
+        $this->assertSame(count($codes), count(array_unique($codes)));
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit tests for promo code generation
- ensure Promocode tests can load class with or without Composer autoloader

## Testing
- `composer install` *(fails: Root composer.json requires php ^7.4 but php version 8.4.11 is installed; ext-gmp and ext-mongodb missing)*
- `vendor/bin/phpunit tests/PromocodeTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893acb89950832997da67b4764bac52