### PR TITLE
chore: add Vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "functions": {
+    "public/index.php": {
+      "runtime": "vercel-php@0.6.0"
+    }
+  },
+  "buildCommand": "composer install --no-dev && npm run prod",
+  "outputDirectory": "public"
+}


### PR DESCRIPTION
## Summary
- add Vercel configuration for PHP runtime and build steps
## Testing
- `composer install --no-interaction` (fails: requires PHP 7.4, missing extensions)
- `composer test` (fails: phpunit not found)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d68b07308329906fcbebf9c4bac0