### PR TITLE
Add Vercel domain CORS and production env settings

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+APP_ENV=production
+APP_URL=https://bitsarcade.vercel.app

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => [env('APP_URL'), 'https://bitsarcade.vercel.app'],
 
     'allowed_origins_patterns' => [],
 


### PR DESCRIPTION
## Summary
- allow Vercel deployment domain through CORS config
- add production environment variables to `.env`

## Testing
- `composer install --no-interaction` *(fails: project requires PHP ^7.4 and missing extensions)*
- `composer test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d68d444c8329b8a5ac41a95a19f6