### PR TITLE
Use environment variable for API URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_URL=https://api.example.com

--- a/resources/js/request.js
+++ b/resources/js/request.js
@@ -6,8 +6,10 @@
  * @param timeout Timeout in ms
  * @returns Promise
  */
+const API_URL = process.env.API_URL || '';
+
 $.request = function(route, options = [], type = 'post', timeout = 25000) {
-    const url = `${!route.startsWith('/') ? '/api/' : ''}${route + (type === 'get' ? arrayToRouteParams(options) : '')}`;
+    const url = `${API_URL}${!route.startsWith('/') ? '/api/' : ''}${route + (type === 'get' ? arrayToRouteParams(options) : '')}`;
     return new Promise(function(resolve, reject) {
         $.ajax({
             url: url,
@@ -79,7 +81,7 @@ function handleApiResponse(url, json, resolve, reject) {
 $.formDataRequest = function(route, options) {
     return new Promise(function(resolve, reject) {
         $.ajax({
-            url: `${!route.startsWith('/') ? '/api/' : ''}${route}`,
+            url: `${API_URL}${!route.startsWith('/') ? '/api/' : ''}${route}`,
             type: 'POST',
             data: options,
             contentType: false,

--- a/watcher.js
+++ b/watcher.js
@@ -5,7 +5,7 @@ var app   = require('express')();
 var http  = require('http').Server(app);
 var io    = require('socket.io')(http);
 const Redis = require('ioredis');
-var domain = 'https://c2c2.datagamble.nl';
+var domain = process.env.API_URL;
 
 var client = new Redis({
    host: '127.0.0.1',
@@ -66,5 +66,6 @@ setInterval(function() {
                             console.log('[STATUS] State file-system restored!');
                         }
     });
-	console.log('[STATUS] State file-system good!');
-}, 100000)
+        console.log('[STATUS] State file-system good!');
+}, 100000);
+

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,0 +1,5 @@
+const mix = require('laravel-mix');
+
+mix.env({
+    API_URL: process.env.API_URL
+});


### PR DESCRIPTION
## Summary
- replace hardcoded API paths in request and watcher scripts with `process.env.API_URL`
- document `API_URL` in new `.env.example`
- expose `API_URL` to front-end via Laravel Mix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a436b8693483298de89833519c0086