### PR TITLE
fix: add serverless PHP entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
-/public
+/public/*
+!/public/index.php
 /ssl
 /app/Console
 /vendor

--- a/api/index.php
+++ b/api/index.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__.'/../public/index.php';

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Laravel - A PHP Framework For Web Artisans
+ *
+ * @package  Laravel
+ * @author   Taylor Otwell <taylor@laravel.com>
+ */
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+
+$kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
+
+$response = $kernel->handle(
+    $request = Illuminate\Http\Request::capture()
+);
+
+$response->send();
+
+$kernel->terminate($request, $response);

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "public/index.php": {
+    "api/index.php": {
       "runtime": "vercel-php@0.6.0"
     }
   },


### PR DESCRIPTION
## Summary
- expose Laravel entrypoint via public/index.php and lightweight api/index.php
- update Vercel config to target api/index.php
- allow committing public/index.php through .gitignore tweak

## Testing
- `npm test`
- `composer install` *(fails: php ^7.4 required)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a43cddd5288329b37f37e5c821fe05