### PR TITLE
chore: update Vercel PHP runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/index.php": {
-      "runtime": "vercel-php@0.6.0"
+      "runtime": "@vercel/php@latest"
     }
   },
   "buildCommand": "composer install --no-dev && npm run prod",


### PR DESCRIPTION
## Summary
- use latest Vercel PHP runtime

## Testing
- `composer install --no-interaction` (fails: Root composer.json requires php ^7.4 but your php version (8.4.11) does not satisfy that requirement)
- `composer test` (fails: phpunit: not found)

------
https://chatgpt.com/codex/tasks/task_e_68ab4c7dd4d48329a9c1c8837e0a67d6