### PR TITLE
chore: parameterize CORS frontend origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+FRONTEND_URL=https://bitsarcade.vercel.app
 API_URL=http://localhost/api
 
 LOG_CHANNEL=stack

--- a/config/cors.php
+++ b/config/cors.php
@@ -16,7 +16,7 @@ return [
     // ✅ Explicitly list allowed origins (env + prod) and use patterns for previews
     'allowed_origins' => array_filter([
         env('APP_URL'),                    // e.g. http://localhost:3000 or https://yourdomain.com
-        'https://bitsarcade.vercel.app',  // production frontend
+        env('FRONTEND_URL', 'https://bitsarcade.vercel.app'),  // production frontend
     ]),
 
     // ✅ Tight preview-domain patterns (adjust to your project naming)


### PR DESCRIPTION
## Summary
- parameterize frontend CORS origin via `FRONTEND_URL`
- document `FRONTEND_URL` in example env config

## Testing
- `composer test` *(fails: phpunit: not found)*
- `composer install` *(fails: repo requires PHP 7.4 and missing extensions)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4c7bfc44832992f320502b11c9e8