### PR TITLE
chore: refine Vercel install/build commands

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,7 @@
       "runtime": "vercel-php@0.6.0"
     }
   },
-  "buildCommand": "composer install --no-dev && npm run prod",
+  "installCommand": "npm install && composer install --no-dev",
+  "buildCommand": "npm run prod",
   "outputDirectory": "public"
 }


### PR DESCRIPTION
## Summary
- specify explicit install command for Vercel deploys
- trigger production build via `npm run prod`

## Testing
- `npm test`
- `composer test` *(fails: phpunit not found; composer install requires PHP 7.4, ext-gmp, ext-mongodb, and GitHub auth)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4c7afcc083299077365dfc07c21d