### PR TITLE
chore: route Vercel traffic to PHP handler

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,9 @@
       "runtime": "vercel-php@0.6.0"
     }
   },
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.php" }
+  ],
   "buildCommand": "composer install --no-dev && npm run prod",
   "outputDirectory": "public"
 }


### PR DESCRIPTION
## Summary
- rewrite all requests to the PHP handler in `vercel.json`

## Testing
- `npm test`
- `composer test` *(fails: phpunit: not found)*
- `composer install` *(fails: PHP version ^7.4 required, missing ext-gmp & ext-mongodb)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4c797b3483299726bb30873e18c6