### PR TITLE
Fix Vercel runtime version declaration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/index.php": {
-      "runtime": "@vercel/php@latest"
+      "runtime": "@vercel/php@0.7.4"
     }
   },
   "routes": [


### PR DESCRIPTION
## Summary
- set the PHP runtime to an explicit version in vercel.json to satisfy Vercel build requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd9398bb4083299ac081111caaea9b